### PR TITLE
added helpers for fetch req and now displaying errors returned from api

### DIFF
--- a/helpers/api.js
+++ b/helpers/api.js
@@ -1,0 +1,36 @@
+import { AsyncStorage } from 'react-native';
+
+const handleResponse = (response) => {
+    return response.json()
+        .then((json) => {
+            if (!response.ok) {
+                const { message } = json;
+                const error = Object.assign({}, json, {
+                    status: response.status,
+                    message: message
+                });
+
+                return Promise.reject(error);
+            }
+            return json;
+        });
+}
+
+const storeData = ({ access_token, user }) => {
+    try {
+        const userData = [
+            ['userToken', access_token],
+            ['user', JSON.stringify(user)]
+        ];
+        AsyncStorage.multiSet(userData);
+        return Promise.resolve();
+    } catch (error) {
+        console.error(error);
+        return Promise.reject({ message: 'Error setting data' });
+    }
+}
+
+export {
+    handleResponse,
+    storeData
+}

--- a/screens/LoginScreen.js
+++ b/screens/LoginScreen.js
@@ -16,6 +16,7 @@ import {
 
 import { ErrorMessage } from '../components/ErrorMessage';
 import { baseUrl } from '../constants/api';
+import { handleResponse, storeData } from '../helpers/api';
 
 export default class LoginScreen extends React.Component {
     static navigationOptions = {
@@ -31,6 +32,10 @@ export default class LoginScreen extends React.Component {
 
     submitForm = async () => {
         const { email, password } = this.state;
+
+        this.setState({
+            errorMessage: ''
+        });
 
         // Validate form has proper fields
         if (!email || !password) {
@@ -54,27 +59,9 @@ export default class LoginScreen extends React.Component {
             },
             body: JSON.stringify(data)
         })
-            .then((response) => {
-                if (response.ok) {
-                    return response.json();
-                } else {
-                    throw Error(
-                        'There was an error, please try again.'
-                    );
-                }
-            })
-            .then(({ access_token, user }) => {
-                try {
-                    const userData = [
-                        ['userToken', access_token],
-                        ['user', JSON.stringify(user)]
-                    ];
-                    AsyncStorage.multiSet(userData);
-                    this.props.navigation.navigate('Main');
-                } catch (error) {
-                    console.log('Error setting data');
-                }
-            })
+            .then(handleResponse)
+            .then(storeData)
+            .then(() => this.props.navigation.navigate('Main'))
             .catch(({ message }) => {
                 this.setState({
                     errorMessage: message

--- a/screens/SignUpScreen.js
+++ b/screens/SignUpScreen.js
@@ -14,6 +14,7 @@ import {
 
 import { ErrorMessage } from '../components/ErrorMessage';
 import { baseUrl } from '../constants/api';
+import { handleResponse, storeData } from '../helpers/api';
 
 export default class SignUpScreen extends React.Component {
     static navigationOptions = {
@@ -37,6 +38,10 @@ export default class SignUpScreen extends React.Component {
             firstName,
             lastName
         } = this.state;
+
+        this.setState({
+            errorMessage: ''
+        });
 
         // Validate form has proper fields
         // @todo validate for email/password
@@ -63,27 +68,9 @@ export default class SignUpScreen extends React.Component {
             },
             body: JSON.stringify(data)
         })
-            .then((response) => {
-                if (response.ok) {
-                    return response.json();
-                } else {
-                    throw Error(
-                        'There was an error, please try again.'
-                    );
-                }
-            })
-            .then(({ access_token, user }) => {
-                try {
-                    const userData = [
-                        ['userToken', access_token],
-                        ['user', JSON.stringify(user)]
-                    ];
-                    AsyncStorage.multiSet(userData);
-                    this.props.navigation.navigate('Main');
-                } catch (error) {
-                    console.log('Error setting data');
-                }
-            })
+            .then(handleResponse)
+            .then(storeData)
+            .then(() => this.props.navigation.navigate('Main'))
             .catch(({ message }) => {
                 this.setState({
                     errorMessage: message


### PR DESCRIPTION
Helper functions `handleResponse` and `storeData` in`helpers/api.js` 
- `handleResponse`: handles the API response
- `storeData`: stores data in async storage
- in turn, either a resolved promise or a rejected one with the appropriate error to display if the response returns an error OR the user info isn't able to be stored for some reason (based on the try-catch for storing the response data in async storage - we may want to switch this up later, but I figure this will be okay for now)
- related-ish but also reset the state for error message to be an empty string each time the form is submitted 

NTS: I started working off of this from @mnicole's earlier PR, so I cherry-picked my commit from that branch onto this new branch to make a new PR after merging that PR. Lot of words... doesn't really matter - just logging for posterity.